### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,5 @@
-const path = require("path");
 const config = (module.exports = require("openmrs/default-webpack-config"));
-config.scriptRuleConfig.exclude =
-  path.sep == "/"
-    ? /(node_modules[^\/@openmrs\/esm\-patient\-common\-lib, ^\/openmrs\-esm\-ohri\-commons\-lib])/
-    : /(node_modules[^\\@openmrs\/esm\-patient\-common\-lib, ^\\openmrs\-esm\-ohri\-commons\-lib])/;
+config.scriptRuleConfig.exclude = /(node_modules(?![/\\](?:@openmrs[/\\]esm-patient-common-lib|openmrs-esm-ohri-commons-lib)))/;
 config.overrides.resolve = {
   extensions: [".tsx", ".ts", ".jsx", ".js", ".scss"],
   alias: {


### PR DESCRIPTION
This is a pretty inconsequential change, but the current `scriptRuleConfig.exclude` rule is probably more permissive than intended. This corrects the regex to only apply to the two libraries intended.

[State machine for the original](https://regexper.com/#%2F%28node_modules%5B%5E%5C%2F%40openmrs%5C%2Fesm%5C-patient%5C-common%5C-lib%2C%20%5E%5C%2Fopenmrs%5C-esm%5C-ohri%5C-commons%5C-lib%5D%29%2F)
[State machine for the change](https://regexper.com/#%2F%28node_modules%28%3F!%5B%2F%5C%5C%5D%28%3F%3A%40openmrs%5B%2F%5C%5C%5Desm-patient-common-lib%7Copenmrs-esm-ohri-commons-lib%29%29%29%2F)