### PR TITLE
EQA-9: Update the coverage script in package.json

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,14 +21,6 @@ module.exports = {
     "!**/src/declarations.d.tsx",
     "!**/e2e/**",
   ],
-  coverageThreshold: {
-    global: {
-      statements: 80,
-      branches: 80,
-      functions: 80,
-      lines: 80,
-    },
-  },
   setupFilesAfterEnv: ["<rootDir>/src/setup-tests.ts"],
   testPathIgnorePatterns: [
     "<rootDir>/packages/esm-form-entry-app",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "lint": "eslint src --ext  js,jsx,ts,tsx --fix",
     "prettier": "prettier --write \"src/**/*.{ts,tsx}\"",
     "typescript": "tsc",
-    "test": "jest --config jest.config.js --passWithNoTests",
+    "test": "jest --config jest.config.js",
     "test-e2e": "playwright test",
     "verify": "concurrently 'yarn:lint' 'yarn:test' 'yarn:typescript'",
-    "coverage": "yarn test -- --coverage",
+    "coverage": "yarn test --coverage",
     "prepare": "husky install",
     "cipublish": "npm publish"
   },


### PR DESCRIPTION
## Summary

The current coverage script is incorrect, causing the GitHub action to not run the unit and integration tests. It is necessary to update the coverage script to resolve this issue.

## Screenshots

*None.*

## Related Issue

- https://swd-icap-eth.atlassian.net/browse/EQA-9

## Other

*None.*